### PR TITLE
Fix not correctly detecting when OpenVPN has died.

### DIFF
--- a/internal/vpn/process.go
+++ b/internal/vpn/process.go
@@ -37,6 +37,9 @@ func (connection *Connection) Started() (bool, error) {
 func (connection *Connection) Running() (bool, error) {
 	processID, err := connection.processID()
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
 		return false, err
 	}
 

--- a/internal/vpn/status.go
+++ b/internal/vpn/status.go
@@ -26,7 +26,7 @@ type Status struct {
 func (connection *Connection) Status() (*Status, error) {
 	managementConnection, err := connection.managementConnection()
 	if err != nil {
-		if _, err := os.Stat(connection.controlSocketPath()); errors.Is(err, os.ErrNotExist) {
+		if _, err := os.Stat(connection.pidPath()); errors.Is(err, os.ErrNotExist) {
 			return &Status{State: StateDisconnected}, nil
 		}
 		return nil, err
@@ -35,7 +35,7 @@ func (connection *Connection) Status() (*Status, error) {
 
 	stateData, err := managementConnection.LatestState()
 	if err != nil {
-		if _, err := os.Stat(connection.controlSocketPath()); errors.Is(err, os.ErrNotExist) {
+		if _, err := os.Stat(connection.pidPath()); errors.Is(err, os.ErrNotExist) {
 			return &Status{State: StateDisconnected}, nil
 		}
 		return nil, errors.Wrap(err, "failed to get latest state")


### PR DESCRIPTION
The control socket doesn't always get deleted when OpenVPN exits. Instead it seems to work better to handle the PID file being deleted.